### PR TITLE
NF - Bug Fix for UX When a Dining Hall is Closed

### DIFF
--- a/frontend/src/main/pages/Meal/MealTimesPage.jsx
+++ b/frontend/src/main/pages/Meal/MealTimesPage.jsx
@@ -10,7 +10,7 @@ export default function MealTimesPage() {
 
   const {
     data: meals,
-    error,
+    error: _error,
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
@@ -18,7 +18,7 @@ export default function MealTimesPage() {
     { url: `/api/diningcommons/${dateTime}/${diningCommonsCode}` },
     // Stryker disable next-line all : don't test default value of empty list
     [],
-    true
+    true,
   );
 
   return (
@@ -28,10 +28,10 @@ export default function MealTimesPage() {
         <h1>
           Meals at {diningCommonsCode} for {dateTime}
         </h1>
-        {error?.response?.status === 500 && (
-          <p>No meals offered today.</p>
-        )}
-        {!error && meals && (
+        {/* length=0 technically means its loading but it only loads for that long when there's an error anyways */}
+        {meals.length === 0 && <p>No meals offered today.</p>}
+        {/* the error takes a few seconds to come through. before that, the status is success, but we still don't want to show the meals table. so the table should only be shown if meals is actually populated */}
+        {meals.length > 0 && (
           <MealTable
             meals={meals}
             dateTime={dateTime}

--- a/frontend/src/main/utils/useBackend.jsx
+++ b/frontend/src/main/utils/useBackend.jsx
@@ -25,7 +25,12 @@ import { toast } from "react-toastify";
 //     []
 // );
 
-export function useBackend(queryKey, axiosParameters, initialData, suppressToasts = false,) {
+export function useBackend(
+  queryKey,
+  axiosParameters,
+  initialData,
+  suppressToasts = false,
+) {
   return useQuery(
     queryKey,
     async () => {


### PR DESCRIPTION
MERGED

Closes #12 

# Summary 

This PR fixes a bug where on days a dining hall is closed, when the page displaying its offered meals (breakfast, lunch, etc) is opened, toast error messages are constantly displayed. 

I fixed the error spam by adding a suppressToasts variable to useBackend() that can be set to true in calls where I expect a 500 error.

I also added a message on the page, "No meals offered today." as clarification for the user. 

Why each file is changed:
MealTimesPage.jsx - adds "No meals offered today." note and sets suppressToasts = true
useBackend.jsx - adds suppressToasts  variable

# To Test

Dokku link: https://dining-fortenatalie.dokku-06.cs.ucsb.edu/

- Click on the "ortega" link
<img width="75" height="32" alt="image" src="https://github.com/user-attachments/assets/a1b45144-57b7-4236-9e4a-2f3023f25797" />

- See "No meals offered today." with no toast error messages:
<img width="743" height="148" alt="image" src="https://github.com/user-attachments/assets/5ede0398-caa9-4992-bdbd-3e766d1b0306" />

IF ITS A WEEKDAY: Note that Ortega is closed only on the weekends. If you are testing on a weekday, please adjust the link in your browser to be https://dining-fortenatalie.dokku-06.cs.ucsb.edu/diningcommons/2025-11-15/ortega. 

# Extra

Details regarding the logic used in the fix:
When the dining hall is closed on a given day, the API call for meals gives a 500 error, after trying a few times then gives up. While it's trying, meals = [] because that is the initialData value in the useBackend() call, but error is not yet 500. After it gives up, meals = [] still and error = 500. So, when deciding when to display "No meals offered today." I use meals.length = 0 rather than the error response status to accelerate loading time.