### PR TITLE
NF - Trying to Fix Failing Tests in Main

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.jsx
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.jsx
@@ -6,8 +6,8 @@ import { useBackend } from "main/utils/useBackend";
 function MealsOfferedCell({ date, diningHall }) {
   const {
     data: meals,
-    error: _error,
-    status: _status,
+    error,
+    status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     [`/api/diningcommons/${date}/${diningHall}`],
@@ -15,26 +15,30 @@ function MealsOfferedCell({ date, diningHall }) {
       url: `/api/diningcommons/${date}/${diningHall}`,
     },
     // Stryker disable next-line all : don't test default value of empty list
-    [],
+    undefined,
     true,
   );
 
-  if (meals.length === 0) return <span>no meals offered</span>;
-  // logic: the api call returns error 500 when there are no meals, and meals remains empty (due to the initialData empty list)
-  // disabled all
+  // Stryker disable OptionalChaining
+  if (error?.response?.status === 500) return <span>no meals offered</span>;
+  if (status === "loading") return <span>Loading...</span>;
 
-  return (
-    <>
-      {meals.map((meal, index) => (
-        <React.Fragment key={meal.code}>
-          {index > 0 && " "}
-          <Link to={`/diningcommons/${date}/${diningHall}/${meal.code}`}>
-            {meal.name}
-          </Link>
-        </React.Fragment> // we have two siblings (" " and link) so a fragment is needed to wrap them together
-      ))}
-    </> // this is also a fragment wrapper, but with no key since we're not inside of a list
-  ); // https://react.dev/reference/react/Fragment#rendering-a-list-of-fragments
+  if (meals) {
+    return (
+      <>
+        {meals.map((meal, index) => (
+          <React.Fragment key={meal.code}>
+            {index > 0 && " "}
+            <Link to={`/diningcommons/${date}/${diningHall}/${meal.code}`}>
+              {meal.name}
+            </Link>
+          </React.Fragment> // we have two siblings (" " and link) so a fragment is needed to wrap them together
+        ))}
+      </> // this is also a fragment wrapper, but with no key since we're not inside of a list
+    ); // https://react.dev/reference/react/Fragment#rendering-a-list-of-fragments
+  }
+
+  return <span>An error has occured.</span>;
 }
 
 export default function DiningCommonsTable({ commons, date }) {

--- a/frontend/src/main/pages/Meal/MealTimesPage.jsx
+++ b/frontend/src/main/pages/Meal/MealTimesPage.jsx
@@ -9,7 +9,7 @@ export default function MealTimesPage() {
     useParams();
 
   const {
-    data: meals = [],
+    data: meals,
     error,
     status,
   } = useBackend(
@@ -31,7 +31,7 @@ export default function MealTimesPage() {
         </h1>
         {status === "loading" && <p>Loading...</p>}
         {error?.response?.status === 500 && <p>No meals offered today.</p>}
-        {meals.length > 0 && (
+        {status === "success" && (
           <MealTable
             meals={meals}
             dateTime={dateTime}

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.jsx
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.jsx
@@ -320,7 +320,7 @@ describe("DiningCommonsTable tests", () => {
     });
 
     axiosMock.reset();
-    axiosMock.onGet(`/api/diningcommons/${date}/portola`).reply(500, []);
+    axiosMock.onGet(`/api/diningcommons/${date}/portola`).reply(500, undefined);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -367,7 +367,6 @@ describe("DiningCommonsTable tests", () => {
       "DiningCommonsTable-cell-row-3-col-mealsOfferedToday",
     );
 
-    // toHaveTextContent ignores spaces, this does not
     expect(cell.textContent).toBe("Breakfast Lunch Dinner");
 
     for (let i = 0; i < mealFixtures.threeMeals.length; i++) {
@@ -380,11 +379,21 @@ describe("DiningCommonsTable tests", () => {
     expect(cell).not.toHaveTextContent("no meals offered");
   });
 
-  test("when loading (empty meal list), have the same behavior as error 500", async () => {
-    queryClient.clear();
+  test("indicate when loading when loading API", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          // ✅ turns retries off
+          retry: false,
+        },
+      },
+    });
 
     axiosMock.reset();
-    axiosMock.onGet(`/api/diningcommons/${date}/portola`).reply(200, []);
+    axiosMock
+      .onGet(`/api/diningcommons/${date}/portola`)
+      .reply(() => new Promise(() => {}));
+    // Above: loading forever
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -402,7 +411,7 @@ describe("DiningCommonsTable tests", () => {
     );
 
     await waitFor(() => {
-      expect(cell).toHaveTextContent("no meals offered");
+      expect(cell).toHaveTextContent("Loading...");
     });
 
     expect(mockToast).not.toHaveBeenCalled();

--- a/frontend/src/tests/pages/Meal/MealTimesPage.test.jsx
+++ b/frontend/src/tests/pages/Meal/MealTimesPage.test.jsx
@@ -100,7 +100,9 @@ describe("MealTimesPage tests", () => {
     });
 
     axiosMock.reset();
-    axiosMock.onGet("/api/diningcommons/2024-11-25/portola").reply(500, []);
+    axiosMock
+      .onGet("/api/diningcommons/2024-11-25/portola")
+      .reply(500, undefined);
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/utils/useBackend.test.jsx
+++ b/frontend/src/tests/utils/useBackend.test.jsx
@@ -70,6 +70,8 @@ describe("utils/useBackend tests", () => {
       expect(errorMessage).toMatch(
         "Error communicating with backend via GET on /api/admin/users",
       );
+
+      expect(mockToast).toHaveBeenCalled();
     });
   });
   describe("utils/useBackend useBackendMutation tests", () => {


### PR DESCRIPTION
Trying to fix the red X in main. 

Also added the "Loading..." message to the main page. 

Red X causes that were solved(?):
- Mutation in useBackend for suppressToasts. I added one line to make the test check that when an error occurs toasts do show up. (https://github.com/ucsb-cs156-f25/proj-dining-f25-06/actions/runs/19624038307/job/56189540412#step:8:186)
- In the DiningCommonsTable tests, a test was failing because when I was testing Portola's output, the other dining halls were getting errors (because I only did the API call for Portola). So I improved how those rows react to errors so the Portola test would work. (https://github.com/ucsb-cs156-f25/proj-dining-f25-06/actions/runs/19650531825/job/56276224378#step:8:13)

Dokku: https://dining-fortenatalie-dev.dokku-06.cs.ucsb.edu/