### PR TITLE
NF - Changing the Node Version that Stryker Uses in Main 

### DIFF
--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -22,6 +22,13 @@ jobs:
         with: 
           fetch-depth: 2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+            node-version-file: './frontend/package.json'
+            cache: 'npm'
+            cache-dependency-path: frontend/package-lock.json
+
       - name: Create directory in case it doesn't exist
         run: |
           mkdir -p frontend/reports


### PR DESCRIPTION
See the green check for the workflow here: https://github.com/ucsb-cs156-f25/proj-dining-f25-06/actions/runs/19688912519

# Context

I asked the TA (Daniel) about why might our tests in main be failing and he said it was likely because of what Node.js version we use.

The Github Action workflow for Stryker is different in our PRs and in main.
- PRs: https://github.com/ucsb-cs156-f25/proj-dining-f25-06/blob/main/.github/workflows/33-frontend-pr-mutation-testing.yml
- Main: https://github.com/ucsb-cs156-f25/proj-dining-f25-06/blob/main/.github/workflows/34-frontend-main-mutation-testing.yml

- The yml testing file for the PRs uses the node version in package.json: 22.18.0
- But in main, the yml testing file doesn't specify a node version so it uses GitHub actions' default(?), which is 20.19.5.

Default node use instance: https://github.com/ucsb-cs156-f25/proj-dining-f25-06/actions/runs/19682710957/job/56380482700#step:8:28

Hypothetically: If we change the Stryker testing file for main to use the newer node version, our code will work.